### PR TITLE
Used latest 3.x.x version of yq

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -57,11 +57,7 @@ install-yq() {
         log install yq
         warn warn sudo is required
         cd /usr/local/bin
-        local URL=$(wget -q -O - https://api.github.com/repos/mikefarah/yq/releases \
-            | jq --raw-output 'map( select(.prerelease==false) | .assets[].browser_download_url ) | .[]' \
-            | grep linux_amd64 \
-            | head -n 1)
-        sudo curl "$URL" \
+        sudo curl "https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64" \
             --progress-bar \
             --location \
             --output yq


### PR DESCRIPTION
Version 4 of `yq` is quite different from the version existed when you wrote this great medium post. Commands that you used in `make.sh` like read, write, delete are no longer exists.

Therefore instead of updating the all `yq` commands in the `make.sh` as mikefarah described in the [migration article](https://mikefarah.gitbook.io/yq/v/v4.x/upgrading-from-v3), I simply changed the download url in the `install-yq `method.

By the way, thanks for the article. It helped me a lot :)


